### PR TITLE
Handle timestamps and durations more robustly

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,7 @@ use crate::utils::{next_span_id, now, serialize_system_time};
 pub enum Value {
     I64(i64),
     U64(u64),
+    F64(f64),
     Bool(bool),
     String(String),
 }
@@ -25,6 +26,12 @@ impl From<i64> for Value {
 impl From<u64> for Value {
     fn from(i: u64) -> Self {
         Value::U64(i)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(i: f64) -> Self {
+        Value::F64(i)
     }
 }
 
@@ -61,6 +68,10 @@ impl Visit for NewrAttributes {
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
+        self.insert(field.name(), value);
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
         self.insert(field.name(), value);
     }
 


### PR DESCRIPTION
The big observable change in this PR is that `duration.ms` is now recorded in New Relic with sub-millisecond precision (the current behavior is to round to the nearest millisecond). There were a few tweaks I made along the way:

1. Update serialization of Unix timestamps to be more robust. Rather than using `as` to cast to a `u64`, `.try_into()` is used instead. In the exceptional case where the number of milliseconds since the Unix epoch no longer fits in a `u64`, the timestamp will not be serialized (just like when measuring the duration since the Unix epoch returns an error in the current code).
2. Add support for sending `f64` values in `NewrAttributes`. Rather than falling back to the default `Debug` implementation, `f64`s will now be serialized as floating-point JSON values.
3. Switch to using [`std::time::Instant`](https://doc.rust-lang.org/stable/std/time/struct.Instant.html) for measuring span durations. This should be more correct, as `Instant` uses a monotonic clock where `SystemTime` uses the system clock. I'm not an expert on different clock types, but my understanding is that this is better but still not perfect.
4. Record `duration.ms` as a floating-point by using [`Duration::as_secs_f64()`](https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.as_secs_f64) as multiplying by 1,000.