### PR TITLE
Include attributes from spans in log attributes

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -53,6 +53,12 @@ impl NewrAttributes {
     pub fn insert<V: Into<Value>>(&mut self, key: &str, val: V) {
         self.0.insert(key.into(), val.into());
     }
+
+    pub fn append(&mut self, other: &Self) {
+        for (key, val) in &other.0 {
+            self.0.entry(key.into()).or_insert_with(|| val.clone());
+        }
+    }
 }
 
 impl Visit for NewrAttributes {


### PR DESCRIPTION
This PR updates `NewRelicLayer` to include more context when sending logs to New Relic. Specifically, it goes through each span in the event's scope and copies the span's attributes into the log's attributes.

As an example use case: imagine your service makes a top-level `request` span each time an HTTP request gets handled (this is what most Tracing web framework integrations do). Let's say that this `request` span has an `http.target` attribute attached. This PR will attach this `http.target` attribute to any event emitted in the scope of that span. In New Relic, this means you could add a filter like `http.target:"/api/hello-world"` and get all logs generated from the `/api/hello-world` endpoint.

I made this change because this matches what our current logging infrastructure does, and we've found it helpful to have span attributes attached to logs in order to filter and browse logs more easily.

I went with a pretty straightforward implementation to get this working, but I'm not sure if it's a good idea to have this behavior enabled without an option to disable it. I'm open to suggestions to revise or improve this PR!